### PR TITLE
Correct read in of hdf5 file to allow for proper slicing

### DIFF
--- a/core.py
+++ b/core.py
@@ -224,6 +224,14 @@ class metaArray(object):
             
             self_info['range'] = range_info(self_info['range'])
             
+            # Make sure they are in list type, they have to be mutable
+            self_info['range']['begin'] = list(self_info['range']['begin']) # Beginning coordinates
+            self_info['range']['end'] = list(self_info['range']['end'])     # Ending coordinates
+            self_info['range']['unit'] = list(self_info['range']['unit'])   # Unit
+            self_info['range']['label'] = list(self_info['range']['label']) # Label
+            self_info['range']['log'] = list(self_info['range']['log'])     # Lin / log scale
+            self_info['range']['fft'] = list(self_info['range']['fft'])     # Data order (see numpy.fft.fftshift)
+            
         else:
             # Range is the corresponding xyz index
             if debug: print "*** Generating default range descriptions"

--- a/drv_h5py.py
+++ b/drv_h5py.py
@@ -134,18 +134,19 @@ def __read_info(h5):
         if isinstance(h5[key], h5py.Group):
             grp_lst.append(key)
         else:
-            info[key] = h5[key][()]
+            content = h5[key][()]
+            
+            if isinstance(content, np.ndarray):
+                content = list(content)
+            elif isinstance(content, tuple):
+                content = list(content)
+            
+            info[key] = content
+            
     
     # Process the grp_lst
     for key in grp_lst:
-        content = __read_info(h5[key])
-        
-        if isinstance(content, np.ndarray):
-            content = list(content)
-        elif isinstance(content, np.ndarray):
-            content = list(content)
-        
-        info[key] = content
+        info[key] = __read_info(h5[key])
     
     return info
 


### PR DESCRIPTION
Forces input hdf5 data for metaInfo['range'] from an ndarray into a list, so that it can be correctly sliced. (drv_h5py.py)

Also in core.py, independently forces info to be a python list. 